### PR TITLE
Seperate mutexes of contexts and global

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -136,9 +136,9 @@ func TestStack(t *testing.T) {
 	})
 	wg.Wait()
 
-	_cm.allmx.RLock()
+	_cm.mxContexts.Lock()
 	assert.Empty(t, _cm.contexts, "No contexts should be left")
-	_cm.allmx.RUnlock()
+	_cm.mxContexts.Unlock()
 }
 
 func BenchmarkPut(b *testing.B) {


### PR DESCRIPTION
Also refactor a bit to separate the responsibility of manager and context more clearly.

For https://github.com/getlantern/lantern-internal/issues/2296

It doesn't "fix" the issue in any sense, but seems a useful refactoring.